### PR TITLE
feat: allow named functions over arrow callbacks

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ module.exports = {
     'operator-linebreak': ['error', 'before'],
     'padded-blocks': 'off',
     'padding-line-between-statements': 'off',
-    'prefer-arrow-callback': 'error',
+    'prefer-arrow-callback': ['warn', {allowNamedFunctions: true}],
     'prefer-const': 'error',
     'prefer-destructuring': 'off',
     'prefer-numeric-literals': 'error',


### PR DESCRIPTION
Arrow callbacks are nice, but in many cases you really want to use named functions for the stack trace readability. Eg:

```js
request.on('error', function onRequestError(err) {
  // Handle
})
```

