### PR TITLE
feat: allow function overloading ("redeclaring") in typescript

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -24,9 +24,14 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    '@typescript-eslint/no-var-requires': 'off',
+
+    // does not understand typescript types/interfaces defined late
     'no-use-before-define': 'off',
 
-    '@typescript-eslint/no-var-requires': 'off', // covered by @typescript-eslint/no-var-requires
+    // prevents function overloading in typescript, so disable base rule
+    'no-redeclare': 'off',
+    '@typescript-eslint/no-redeclare': ['error'],
   },
   overrides: [
     {


### PR DESCRIPTION
By disabling the built-in "no-redeclare" rule, we allow typescript method overloading, eg:
```ts
function pickCard(x: { suit: string; card: number }[]): number;
function pickCard(x: number): { suit: string; card: number };
function pickCard(x: any): any {
  // do something
}
```