### PR TITLE
feat: disable operator-linebreak because of prettier mismatch

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,7 +212,7 @@ module.exports = {
     'one-var': ['error', 'never'],
     'one-var-declaration-per-line': 'off',
     'operator-assignment': ['error', 'always'],
-    'operator-linebreak': ['error', 'before'],
+    'operator-linebreak': 'off', // conflicts with prettier
     'padded-blocks': 'off',
     'padding-line-between-statements': 'off',
     'prefer-arrow-callback': 'error',


### PR DESCRIPTION
I don't think this is the most important rule in our eslint config, and it causes (potential) issues with prettier unless you're also using the prettier eslint config. I think prettier is pretty much in play everywhere now, so lets leave it up to prettier to decide?