### PR TITLE
feat: allow certain camelcased vars (unstable, unsafe)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     'block-spacing': ['error', 'always'],
     'brace-style': ['error', '1tbs', {allowSingleLine: false}],
     'callback-return': 'error',
-    camelcase: 'error',
+    camelcase: ['error', {allow: ['^_*unstable_', '^UNSAFE_']}],
     'capitalized-comments': 'off',
     'class-methods-use-this': 'warn',
     'comma-dangle': 'off',


### PR DESCRIPTION
While I think we should stick to camelcase where possible, there are a few annoying exceptions - eg `unstable`, `__unstable_someThing` and `UNSAFE_component...` that I think it would be nice not to have to add exceptions for. 
